### PR TITLE
feat(backend): add delay on login, reg, recovery requests

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -5,11 +5,13 @@ from app.helpers import now
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
+from app.helpers import delay_to_minimum
 
 router = APIRouter(tags=["auth"])
 
 
 @router.post("/token", response_model=schemas.TokenResponse)
+@delay_to_minimum(1)
 async def login(
     request: Request,
     form_data: OAuth2PasswordRequestForm = Depends(),

--- a/backend/app/api/user.py
+++ b/backend/app/api/user.py
@@ -3,11 +3,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 import app.db.models as models, app.db as db, app.schemas as schemas, app.core.auth as auth, app.enums as enums
 from app.core.user import delete_user as _delete_user
 from sqlalchemy import select
+from app.helpers import delay_to_minimum
 
 router = APIRouter(tags=["user"])
 
 
 @router.post("/user", response_model=schemas.User)
+@delay_to_minimum(1)
 async def create_user(
     user: schemas.UserCreate,
     session: AsyncSession = Depends(db.get_async_session),

--- a/backend/app/helpers/__init__.py
+++ b/backend/app/helpers/__init__.py
@@ -1,1 +1,2 @@
 from .now import now
+from .delay_to_minimum import delay_to_minimum

--- a/backend/app/helpers/delay_to_minimum.py
+++ b/backend/app/helpers/delay_to_minimum.py
@@ -1,0 +1,29 @@
+import time
+import asyncio
+from functools import wraps
+from typing import Callable
+
+
+def delay_to_minimum(min_seconds: float = 1):
+    """
+    Decorator for async functions
+    that delays result if the execution was faster
+    :param min_seconds minimum execution time in seconds
+    """
+
+    def decorator(func: Callable):
+        @wraps(func)
+        async def wrapper(*args, **kwargs):
+            start = time.monotonic()
+            try:
+                result = await func(*args, **kwargs)
+                return result
+            finally:
+                elapsed = time.monotonic() - start
+                delay = max(0, min_seconds - elapsed)
+                if delay > 0:
+                    await asyncio.sleep(delay)
+
+        return wrapper
+
+    return decorator


### PR DESCRIPTION
+ add delay_to_minimum decorator
+ apply it to login, register and password recovery requests
+ recovery request always never raise error
+ run EmailSender.send_password_reset_email (may take a while, don't wait)

Close #23