### PR TITLE
fix: after update changelog may have been loaded from cache

### DIFF
--- a/frontend/ngsw-config.json
+++ b/frontend/ngsw-config.json
@@ -11,7 +11,7 @@
       "cacheConfig": {
         "maxAge": "90d",
         "maxSize": 100,
-        "timeout": "5s",
+        "timeout": "3s",
         "strategy": "freshness"
       }
     }
@@ -47,7 +47,7 @@
       "updateMode": "prefetch",
       "resources": {
         "files": [
-          "/**/*.(svg|cur|jpg|jpeg|png|apng|webp|avif|gif|otf|ttf|woff|woff2)"
+          "/**/*.(svg|cur|jpg|jpeg|png|apng|webp|avif|gif|otf|ttf|woff|woff2|md)"
         ]
       }
     }

--- a/frontend/src/app/features/about/about.component.html
+++ b/frontend/src/app/features/about/about.component.html
@@ -10,7 +10,7 @@
       </span>
       <mat-icon matListItemIcon>open_in_new</mat-icon>
     </a>
-    @if (version$ | async; as version) {
+    @if (version(); as version) {
     <mat-list-item role="">
       <span matListItemTitle>
         {{ 'ABOUT.IMAGE_VERSION' | translate }} {{ version.image_version }}

--- a/frontend/src/app/features/about/about.component.ts
+++ b/frontend/src/app/features/about/about.component.ts
@@ -1,4 +1,3 @@
-import { AsyncPipe } from '@angular/common';
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import {
   MatList,
@@ -7,20 +6,19 @@ import {
   MatListItemTitle,
 } from '@angular/material/list';
 import { TranslateModule } from '@ngx-translate/core';
-import { PublicApiService } from 'src/app/entities/public/public-api.service';
 import { MatIcon } from '@angular/material/icon';
-import { catchError, of, retry } from 'rxjs';
-import { SnackService } from 'src/app/core/services/snack.service';
 import { CodeExamplesComponent } from '../code-examples/code-examples.component';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { ChangelogComponent } from 'src/app/shared/components/changelog/changelog.component';
+import { Store } from '@ngrx/store';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { selectAppVersion } from 'src/app/state/app.selectors';
 
 @Component({
   selector: 'app-about',
   imports: [
     MatList,
     MatListItem,
-    AsyncPipe,
     TranslateModule,
     MatIcon,
     MatListItemTitle,
@@ -34,14 +32,7 @@ import { ChangelogComponent } from 'src/app/shared/components/changelog/changelo
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AboutComponent {
-  private readonly publicApiService = inject(PublicApiService);
-  private readonly snackService = inject(SnackService);
+  private readonly store = inject(Store);
 
-  public readonly version$ = this.publicApiService.version().pipe(
-    retry({ count: 1, delay: 1000 }),
-    catchError((error) => {
-      this.snackService.error(error);
-      return of(null);
-    }),
-  );
+  public readonly version = toSignal(this.store.select(selectAppVersion));
 }

--- a/frontend/src/app/state/app.actions.ts
+++ b/frontend/src/app/state/app.actions.ts
@@ -6,7 +6,10 @@ import {
   VersionReadyEvent,
 } from '@angular/service-worker';
 import { createActionGroup, emptyProps, props } from '@ngrx/store';
-import { IPublicSettingsItem } from '../entities/public/public-interface';
+import {
+  IPublicSettingsItem,
+  IVersion,
+} from '../entities/public/public-interface';
 import { HttpErrorResponse } from '@angular/common/http';
 
 export const AppActions = createActionGroup({
@@ -16,6 +19,9 @@ export const AppActions = createActionGroup({
     getPublicSettings: emptyProps(),
     getPublicSettingsSuccess: props<{ settings: IPublicSettingsItem[] }>(),
     getPublicSettingsError: props<{ error: HttpErrorResponse }>(),
+    getVersion: emptyProps(),
+    getVersionSuccess: props<{ version: IVersion }>(),
+    getVersionError: props<{ error: HttpErrorResponse }>(),
     networkOnline: emptyProps(),
     networkOffline: emptyProps(),
     versionDetected: props<{ event: VersionDetectedEvent }>(),

--- a/frontend/src/app/state/app.reducers.ts
+++ b/frontend/src/app/state/app.reducers.ts
@@ -1,15 +1,29 @@
 import { createReducer, on } from '@ngrx/store';
 import { AppActions } from './app.actions';
-import { IPublicSettingsItem } from '../entities/public/public-interface';
+import {
+  IPublicSettingsItem,
+  IVersion,
+} from '../entities/public/public-interface';
 
 export const baseActionPrefix: string = '[CARDHOLDER]';
 export interface IAppState {
+  /**
+   * Connection state
+   */
   isOnline: boolean;
+  /**
+   * Public app settings from api
+   */
   settings: IPublicSettingsItem[];
+  /**
+   * Current version
+   */
+  version: IVersion;
 }
 export const initialState: IAppState = {
   isOnline: false,
   settings: [],
+  version: null,
 };
 export const appReducer = createReducer(
   initialState,
@@ -20,6 +34,14 @@ export const appReducer = createReducer(
   on(AppActions.getPublicSettingsError, (state, payload) => ({
     ...state,
     settings: [],
+  })),
+  on(AppActions.getVersionSuccess, (state, payload) => ({
+    ...state,
+    version: payload.version,
+  })),
+  on(AppActions.getVersionError, (state, payload) => ({
+    ...state,
+    version: null,
   })),
   on(AppActions.networkOnline, (state, payload) => ({
     ...state,

--- a/frontend/src/app/state/app.selectors.ts
+++ b/frontend/src/app/state/app.selectors.ts
@@ -39,3 +39,7 @@ export const selectAppSmtpDisabled = createSelector(_selectApp, (state) =>
     false,
   ),
 );
+export const selectAppVersion = createSelector(
+  _selectApp,
+  (state) => state.version,
+);


### PR DESCRIPTION
+ add app version to app state
+ add query parameter to changelog request (bypass cache)
+ add md extension to ngsw config assets
+ replace request of version to state version on About page
+ reduce sw timeout for /api to 3 secs (should be enough for more or less normal conn)

Related to #31