### PR TITLE
fix(frontend): sw caching and updating

### DIFF
--- a/frontend/ngsw-config.json
+++ b/frontend/ngsw-config.json
@@ -47,7 +47,17 @@
       "updateMode": "prefetch",
       "resources": {
         "files": [
-          "/**/*.(svg|cur|jpg|jpeg|png|apng|webp|avif|gif|otf|ttf|woff|woff2|md)"
+          "/**/*.(svg|cur|jpg|jpeg|png|apng|webp|avif|gif|otf|ttf|woff|woff2)"
+        ]
+      }
+    },
+    {
+      "name": "no-cache",
+      "installMode": "lazy",
+      "updateMode": "lazy",
+      "resources": {
+        "files": [
+          "/**/CHANGELOG.md"
         ]
       }
     }


### PR DESCRIPTION
+ disable sw cache for CHANGELOG.md
+ check for update on visibilitychange (in case app opened from ram, not unloaded)
+ wait for service worker ready before changelog dialog

Related to #31 