### PR TITLE
fix(frontend): default to the rear camera the platform grants

### DIFF
--- a/frontend/src/app/features/card-scanner/card-scanner.component.spec.ts
+++ b/frontend/src/app/features/card-scanner/card-scanner.component.spec.ts
@@ -44,6 +44,13 @@ const testMediaDevices: MediaDeviceInfo[] = [
     toJSON: null,
   },
   {
+    deviceId: 'backcamera2',
+    groupId: null,
+    kind: 'videoinput',
+    label: 'Back camera',
+    toJSON: null,
+  },
+  {
     deviceId: 'somespeaker',
     groupId: null,
     kind: 'audiooutput',
@@ -51,6 +58,18 @@ const testMediaDevices: MediaDeviceInfo[] = [
     toJSON: null,
   },
 ];
+
+/** Stream stub exposing the camera the platform granted. */
+const grantedStream = (deviceId: string) => {
+  const track = {
+    getSettings: () => ({ deviceId }),
+    stop: vi.fn(),
+  } as unknown as MediaStreamTrack;
+  return {
+    getVideoTracks: () => [track],
+    getTracks: () => [track],
+  } as unknown as MediaStream;
+};
 
 describe('CardScannerComponent', () => {
   let component: CardScannerComponent;
@@ -110,7 +129,25 @@ describe('CardScannerComponent', () => {
     expect(snackServiceMock.error).toHaveBeenCalledTimes(1);
   });
 
-  it('should select first environment camera as default', async () => {
+  it('should default to the camera granted by the platform', async () => {
+    mediaDevicesServiceMock.getUserMedia.mockResolvedValue(
+      grantedStream('backcamera2'),
+    );
+    mediaDevicesServiceMock.enumerateDevices.mockResolvedValue(
+      testMediaDevices,
+    );
+    fixture = TestBed.createComponent(CardScannerComponent);
+    component = fixture.componentInstance;
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    await fixture.whenRenderingDone();
+    TestBed.tick();
+
+    expect(component['selectedDevice']()).toEqual(testMediaDevices[3]);
+  });
+
+  it('should fall back to the label when no device id is reported', async () => {
     if (typeof globalThis.MediaStream === 'undefined') {
       globalThis.MediaStream = class {} as typeof MediaStream;
     }

--- a/frontend/src/app/features/card-scanner/card-scanner.component.ts
+++ b/frontend/src/app/features/card-scanner/card-scanner.component.ts
@@ -7,7 +7,7 @@ import {
   viewChild,
 } from '@angular/core';
 import { MatButton, MatIconButton } from '@angular/material/button';
-import { catchError, from, map, of, switchMap } from 'rxjs';
+import { catchError, from, map, of, switchMap, tap } from 'rxjs';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import {
   MatDialog,
@@ -128,11 +128,22 @@ export class CardScannerComponent implements OnDestroy {
   >('scanner', { read: CardScannerBaseComponent });
 
   /**
+   * Device id the platform granted for the rear camera request, when it
+   * reports one. Used as the default camera, see getDefaultDevice.
+   */
+  private readonly grantedDeviceId = signal<string>(null);
+
+  /**
    * Media device list.
    * That is also initiates permission dialog.
    */
   private readonly devices = toSignal(
-    from(this.mediaDevicesService.getUserMedia({ video: true })).pipe(
+    from(
+      this.mediaDevicesService.getUserMedia({
+        video: { facingMode: { ideal: 'environment' } },
+      }),
+    ).pipe(
+      tap((stream) => this.readGrantedDevice(stream)),
       switchMap(() => from(this.mediaDevicesService.enumerateDevices())),
       map((res) =>
         (res || []).filter((d) => !d.kind || d.kind.includes('video')),
@@ -152,7 +163,7 @@ export class CardScannerComponent implements OnDestroy {
       const devices = this.devices();
       const device = this.selectedDevice();
       if (devices.length && !device) {
-        const device = this.getDefaultDeviceByLabel(devices);
+        const device = this.getDefaultDevice(devices);
         this.selectedDevice.set(device);
       }
     });
@@ -226,12 +237,40 @@ export class CardScannerComponent implements OnDestroy {
     this.matDialog.open(CardScannerHelpDialogComponent);
   }
 
-  private getDefaultDeviceByLabel(devices: MediaDeviceInfo[]): MediaDeviceInfo {
+  /**
+   * Keeps the camera the platform actually granted, then releases the stream:
+   * it was only opened to raise the permission dialog and to read that id.
+   */
+  private readGrantedDevice(stream: MediaStream): void {
+    const track = stream?.getVideoTracks?.()?.[0];
+    this.grantedDeviceId.set(track?.getSettings?.()?.deviceId || null);
+    stream?.getTracks?.().forEach((t) => t.stop());
+  }
+
+  /**
+   * Default camera.
+   *
+   * Matching on the label alone is not enough on Android: phones expose
+   * several rear cameras (wide, ultra wide, telephoto, depth) and they all
+   * carry "back" in their label, so the first match is often the ultra wide
+   * one, which cannot focus close enough to read a barcode.
+   *
+   * The rear camera request above lets the platform pick the main one, so
+   * prefer the device it granted and keep the label match as a fallback for
+   * browsers that report no device id.
+   */
+  private getDefaultDevice(devices: MediaDeviceInfo[]): MediaDeviceInfo {
     if (!devices?.length) {
       return null;
     }
+    const grantedId = this.grantedDeviceId();
+    const granted = grantedId
+      ? devices.find((d) => d.deviceId === grantedId)
+      : undefined;
     return (
-      devices.find((d) => /back|rear|environment/i.test(d.label)) || devices[0]
+      granted ??
+      devices.find((d) => /back|rear|environment/i.test(d.label)) ??
+      devices[0]
     );
   }
 }


### PR DESCRIPTION
On Android the scanner opens on the wrong camera almost every time, and the picture will not focus on a barcode. Switching camera by hand fixes it for that scan, then it comes back on the next one.

The default is picked from the device label:

```ts
devices.find((d) => /back|rear|environment/i.test(d.label)) || devices[0]
```

Modern phones expose several rear cameras - wide, ultra wide, telephoto, depth - and all of them carry `back` in their label. `find` returns whichever comes first in the enumeration, which on the phones I have at hand is the ultra wide: minimum focus distance far too long for a code held at arm's length.

Rather than guessing from labels, this asks for `facingMode: 'environment'` on the permission call and reads the device id back from the granted track. That is the camera the platform itself considers the main rear one. The label match is kept as a fallback, since some browsers return an empty device id before permission is fully settled.

Two smaller things came with it:

- the permission stream is released once its id has been read. It used to stay open for as long as the dialog lived, on top of the stream the scanner opens right after.
- the existing default-camera test now runs against a device list holding two rear cameras, which is what the old code got wrong. Added a test for the granted-device path.

Tested on Android (Chrome) with a three-camera phone, and on desktop Firefox with a single webcam.