### PR TITLE
fix(backend): require the current password to change credentials

### DIFF
--- a/backend/api/user_api.py
+++ b/backend/api/user_api.py
@@ -73,7 +73,7 @@ async def update_user(
         if not data.current_password or not verify_password(
             data.current_password, current_user.hashed_password
         ):
-            raise HTTPException(401, detail="Current password is incorrect")
+            raise HTTPException(400, detail="Current password is incorrect")
 
     if data.username != current_user.username:
         current_user.username = data.username

--- a/backend/api/user_api.py
+++ b/backend/api/user_api.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.core.auth_core import (
@@ -7,8 +7,10 @@ from backend.core.auth_core import (
     get_password_hash,
     is_creds_taken,
     is_user,
+    verify_password,
 )
 from backend.core.user_core import delete_user as _delete_user
+from backend.db.models.refresh_token_model import RefreshTokenModel
 from backend.db.models.user_model import UserModel
 from backend.db.session import get_async_session
 from backend.enums.user_role_enum import EUserRole
@@ -66,14 +68,32 @@ async def update_user(
     )
     if creds_taken:
         raise HTTPException(400, detail="Username or email is already taken")
+    email_changed = data.email != current_user.email
+    if data.password or email_changed:
+        if not data.current_password or not verify_password(
+            data.current_password, current_user.hashed_password
+        ):
+            raise HTTPException(401, detail="Current password is incorrect")
+
     if data.username != current_user.username:
         current_user.username = data.username
-    if data.email != current_user.email:
+    if email_changed:
         current_user.email = data.email
     if data.password:
         current_user.hashed_password = get_password_hash(data.password)
     await session.commit()
     await session.refresh(current_user)
+
+    if data.password:
+        # Same as after a recovery: a new password ends the old sessions,
+        # so a stolen refresh token does not outlive the change.
+        await session.execute(
+            update(RefreshTokenModel)
+            .where(RefreshTokenModel.user_id == current_user.id)
+            .values(revoked=True)
+        )
+        await session.commit()
+
     return current_user
 
 

--- a/backend/schemas/user_schema.py
+++ b/backend/schemas/user_schema.py
@@ -35,10 +35,15 @@ class UserCreateSchema(BaseModel):
 
 
 class UserUpdateSchema(BaseModel):
-    """User update schema. Passwords optional"""
+    """User update schema. Passwords optional.
+
+    current_password is required by the endpoint when the password or the
+    email address changes, since both are enough to take the account over.
+    """
 
     username: str
     email: EmailStr
+    current_password: str | None = None
     password: str | None = None
     confirm_password: str | None = None
 

--- a/backend/test/api/test_user.py
+++ b/backend/test/api/test_user.py
@@ -227,7 +227,7 @@ async def test_user_should_not_change_password_without_current_one() -> None:
         with pytest.raises(HTTPException) as exc_info:
             await update_user(user, session_mock, current_user)
 
-    assert exc_info.value.status_code == 401
+    assert exc_info.value.status_code == 400
     assert verify_password(CURRENT_PASSWORD, current_user.hashed_password)
 
 
@@ -255,7 +255,7 @@ async def test_user_should_not_change_password_with_a_wrong_current_one() -> Non
         with pytest.raises(HTTPException) as exc_info:
             await update_user(user, session_mock, current_user)
 
-    assert exc_info.value.status_code == 401
+    assert exc_info.value.status_code == 400
 
 
 @pytest.mark.asyncio
@@ -279,5 +279,5 @@ async def test_user_should_not_change_email_without_current_password() -> None:
         with pytest.raises(HTTPException) as exc_info:
             await update_user(user, session_mock, current_user)
 
-    assert exc_info.value.status_code == 401
+    assert exc_info.value.status_code == 400
     assert current_user.email == "user_email@example.com"

--- a/backend/test/api/test_user.py
+++ b/backend/test/api/test_user.py
@@ -5,7 +5,7 @@ from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.api.user_api import create_user, update_user
-from backend.core.auth_core import verify_password
+from backend.core.auth_core import get_password_hash, verify_password
 from backend.db.models.user_model import UserModel
 from backend.enums.user_role_enum import EUserRole
 from backend.schemas.user_schema import (
@@ -122,7 +122,7 @@ async def test_user_should_not_update_if_creds_taken() -> None:
 @pytest.mark.asyncio
 async def test_user_should_update_with_no_password() -> None:
     user = _get_user_update()
-    current_user: UserModel = UserModel(id=1)
+    current_user = _get_current_user()
 
     session_mock = AsyncMock(spec=AsyncSession)
 
@@ -137,17 +137,30 @@ async def test_user_should_update_with_no_password() -> None:
         assert result.email == user.email
 
 
+CURRENT_PASSWORD = "current1Q"
+
+
+def _get_current_user(email: str = "user_email@example.com") -> UserModel:
+    return UserModel(
+        id=1,
+        username="user_name",
+        email=email,
+        hashed_password=get_password_hash(CURRENT_PASSWORD),
+    )
+
+
 @pytest.mark.asyncio
 async def test_user_should_update_with_password() -> None:
     user = _get_user_update(
         {
             "username": "user_name",
             "email": "user_email@example.com",
+            "current_password": CURRENT_PASSWORD,
             "password": "123456qQ",
             "confirm_password": "123456qQ",
         }
     )
-    current_user: UserModel = UserModel(id=1)
+    current_user = _get_current_user()
 
     session_mock = AsyncMock(spec=AsyncSession)
 
@@ -161,3 +174,110 @@ async def test_user_should_update_with_password() -> None:
         assert result.username == user.username
         assert result.email == user.email
         assert verify_password("123456qQ", result.hashed_password)
+
+
+@pytest.mark.asyncio
+async def test_user_should_revoke_sessions_on_password_change() -> None:
+    user = _get_user_update(
+        {
+            "username": "user_name",
+            "email": "user_email@example.com",
+            "current_password": CURRENT_PASSWORD,
+            "password": "123456qQ",
+            "confirm_password": "123456qQ",
+        }
+    )
+    current_user = _get_current_user()
+
+    session_mock = AsyncMock(spec=AsyncSession)
+
+    with patch(
+        "backend.api.user_api.is_creds_taken",
+        new_callable=AsyncMock,
+    ) as is_creds_taken_mock:
+        is_creds_taken_mock.return_value = False
+        await update_user(user, session_mock, current_user)
+
+    statements = [
+        str(call.args[0]) for call in session_mock.execute.mock_calls if call.args
+    ]
+    assert any("UPDATE refresh_token" in stmt for stmt in statements)
+
+
+@pytest.mark.asyncio
+async def test_user_should_not_change_password_without_current_one() -> None:
+    user = _get_user_update(
+        {
+            "username": "user_name",
+            "email": "user_email@example.com",
+            "password": "123456qQ",
+            "confirm_password": "123456qQ",
+        }
+    )
+    current_user = _get_current_user()
+
+    session_mock = AsyncMock(spec=AsyncSession)
+
+    with patch(
+        "backend.api.user_api.is_creds_taken",
+        new_callable=AsyncMock,
+    ) as is_creds_taken_mock:
+        is_creds_taken_mock.return_value = False
+
+        with pytest.raises(HTTPException) as exc_info:
+            await update_user(user, session_mock, current_user)
+
+    assert exc_info.value.status_code == 401
+    assert verify_password(CURRENT_PASSWORD, current_user.hashed_password)
+
+
+@pytest.mark.asyncio
+async def test_user_should_not_change_password_with_a_wrong_current_one() -> None:
+    user = _get_user_update(
+        {
+            "username": "user_name",
+            "email": "user_email@example.com",
+            "current_password": "wrong1Qq",
+            "password": "123456qQ",
+            "confirm_password": "123456qQ",
+        }
+    )
+    current_user = _get_current_user()
+
+    session_mock = AsyncMock(spec=AsyncSession)
+
+    with patch(
+        "backend.api.user_api.is_creds_taken",
+        new_callable=AsyncMock,
+    ) as is_creds_taken_mock:
+        is_creds_taken_mock.return_value = False
+
+        with pytest.raises(HTTPException) as exc_info:
+            await update_user(user, session_mock, current_user)
+
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_user_should_not_change_email_without_current_password() -> None:
+    user = _get_user_update(
+        {
+            "username": "user_name",
+            "email": "new_email@example.com",
+        }
+    )
+    current_user = _get_current_user()
+
+    session_mock = AsyncMock(spec=AsyncSession)
+
+    with patch(
+        "backend.api.user_api.is_creds_taken",
+        new_callable=AsyncMock,
+    ) as is_creds_taken_mock:
+        is_creds_taken_mock.return_value = False
+
+        with pytest.raises(HTTPException) as exc_info:
+            await update_user(user, session_mock, current_user)
+
+    assert exc_info.value.status_code == 401
+    assert current_user.email == "user_email@example.com"

--- a/frontend/public/i18n/en.json
+++ b/frontend/public/i18n/en.json
@@ -112,6 +112,7 @@
     "USERNAME": "Username",
     "EMAIL": "E-mail",
     "CHANGE_PASSWORD": "Change password",
+    "CURRENT_PASSWORD": "Current password",
     "PASSWORD": "Password",
     "CONFIRM_PASSWORD": "Confirm password",
     "PASSWORDS_MISMATCH": "Passwords do not match",

--- a/frontend/public/i18n/fr.json
+++ b/frontend/public/i18n/fr.json
@@ -112,6 +112,7 @@
     "USERNAME": "Nom d'utilisateur",
     "EMAIL": "E-mail",
     "CHANGE_PASSWORD": "Changer le mot de passe",
+    "CURRENT_PASSWORD": "Mot de passe actuel",
     "PASSWORD": "Mot de passe",
     "CONFIRM_PASSWORD": "Confirmer le mot de passe",
     "PASSWORDS_MISMATCH": "Les mots de passe ne correspondent pas",

--- a/frontend/public/i18n/ru.json
+++ b/frontend/public/i18n/ru.json
@@ -112,6 +112,7 @@
     "USERNAME": "Имя пользователя",
     "EMAIL": "E-mail",
     "CHANGE_PASSWORD": "Изменить пароль",
+    "CURRENT_PASSWORD": "Текущий пароль",
     "PASSWORD": "Пароль",
     "CONFIRM_PASSWORD": "Повторить пароль",
     "PASSWORDS_MISMATCH": "Пароли не совпадают",

--- a/frontend/src/app/entities/user/user-interface.ts
+++ b/frontend/src/app/entities/user/user-interface.ts
@@ -15,6 +15,8 @@ export interface IUserCreate {
 export interface IUserUpdate {
   username: string;
   email: string;
+  /** Required by the api when the password or the email changes. */
+  current_password?: string;
   password?: string;
   confirm_password?: string;
 }

--- a/frontend/src/app/features/user/user.component.html
+++ b/frontend/src/app/features/user/user.component.html
@@ -26,6 +26,25 @@
         autocomplete="username"
         formControlName="username" />
     </mat-form-field>
+    @if (needsCurrentPassword()) {
+      <mat-form-field class="user-component-form-field">
+        <mat-label aria-required="true">{{
+          'USER.CURRENT_PASSWORD' | translate
+        }}</mat-label>
+        <input
+          matInput
+          [type]="hideCurrentPassword() ? 'password' : 'text'"
+          id="current-password"
+          name="current-password"
+          autocomplete="current-password"
+          formControlName="current_password" />
+        <mat-icon
+          matSuffix
+          (click)="hideCurrentPassword.set(!hideCurrentPassword())">
+          {{ hideCurrentPassword() ? 'visibility_off' : 'visibility' }}
+        </mat-icon>
+      </mat-form-field>
+    }
     <mat-checkbox
       #changePasswordCheckbox
       class="user-component-form-checkbox"

--- a/frontend/src/app/features/user/user.component.spec.ts
+++ b/frontend/src/app/features/user/user.component.spec.ts
@@ -43,10 +43,45 @@ describe('UserComponent', () => {
     const body = {
       username: 'user1',
       email: 'testemail1@example.com',
+      current_password: 'currentPass1',
     };
     component['form'].patchValue(body);
     component['onSubmit']();
 
+    expect(dispatchSpy).toHaveBeenCalledWith(UserActions.update({ body }));
+  });
+
+  it('should not change the email without the current password', () => {
+    fixture = TestBed.createComponent(UserComponent);
+    component = fixture.componentInstance;
+    const dispatchSpy = vi.spyOn(storeMock, 'dispatch');
+    fixture.detectChanges();
+
+    component['form'].patchValue({
+      username: 'user1',
+      email: 'testemail1@example.com',
+    });
+    component['onSubmit']();
+
+    expect(dispatchSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: UserActions.update.type }),
+    );
+  });
+
+  it('should not ask for the current password on an unrelated edit', () => {
+    fixture = TestBed.createComponent(UserComponent);
+    component = fixture.componentInstance;
+    const dispatchSpy = vi.spyOn(storeMock, 'dispatch');
+    fixture.detectChanges();
+
+    const body = {
+      username: 'user1',
+      email: 'testemail@gmail.com',
+    };
+    component['form'].patchValue(body);
+    component['onSubmit']();
+
+    expect(component['needsCurrentPassword']()).toBe(false);
     expect(dispatchSpy).toHaveBeenCalledWith(UserActions.update({ body }));
   });
 
@@ -89,6 +124,7 @@ describe('UserComponent', () => {
     const body = {
       username: 'user1',
       email: 'testemail1@example.com',
+      current_password: 'currentPass1',
       password: '12345678qQ',
       confirm_password: '12345678qQ',
     };
@@ -96,6 +132,27 @@ describe('UserComponent', () => {
     component['onSubmit']();
 
     expect(dispatchSpy).toHaveBeenCalledWith(UserActions.update({ body }));
+  });
+
+  it('should require the current password to change the password', () => {
+    fixture = TestBed.createComponent(UserComponent);
+    component = fixture.componentInstance;
+    const dispatchSpy = vi.spyOn(storeMock, 'dispatch');
+    fixture.detectChanges();
+
+    component['onChangePasswordCheck']({ checked: true, source: null });
+    component['form'].patchValue({
+      username: 'testusername',
+      email: 'testemail@gmail.com',
+      password: '12345678qQ',
+      confirm_password: '12345678qQ',
+    });
+    component['onSubmit']();
+
+    expect(component['needsCurrentPassword']()).toBe(true);
+    expect(dispatchSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: UserActions.update.type }),
+    );
   });
 
   it('should not update password if unchecked', () => {
@@ -108,6 +165,7 @@ describe('UserComponent', () => {
     const body = {
       username: 'user1',
       email: 'testemail1@example.com',
+      current_password: 'currentPass1',
       password: '12345678qQ',
       confirm_password: '12345678qQ',
     };
@@ -117,7 +175,11 @@ describe('UserComponent', () => {
 
     expect(dispatchSpy).toHaveBeenCalledWith(
       UserActions.update({
-        body: { username: 'user1', email: 'testemail1@example.com' },
+        body: {
+          username: 'user1',
+          email: 'testemail1@example.com',
+          current_password: 'currentPass1',
+        },
       }),
     );
   });

--- a/frontend/src/app/features/user/user.component.ts
+++ b/frontend/src/app/features/user/user.component.ts
@@ -60,6 +60,7 @@ export class UserComponent implements OnInit {
   protected readonly isOwner = this.store.selectSignal(selectUserIsOwner);
   protected readonly isLoading = this.store.selectSignal(selectUserIsLoading);
   protected readonly hasChanges = this.store.selectSignal(selectUserHasChanges);
+  protected readonly hideCurrentPassword = signal(true);
   protected readonly hidePassword = signal(true);
   protected readonly hideConfirmPassword = signal(true);
 
@@ -82,9 +83,19 @@ export class UserComponent implements OnInit {
         Validators.required,
         Validators.email,
       ]),
+      current_password: new FormControl<string>({
+        value: null,
+        disabled: true,
+      }),
     },
     passwordMatchValidator(),
   );
+
+  /** Email as it is stored, to tell an actual change from a re-typed value. */
+  private readonly storedEmail = signal<string>(null);
+
+  /** The api asks for the current password when either of those changes. */
+  protected readonly needsCurrentPassword = signal(false);
 
   private get value(): IUserUpdate {
     return this.form.value as IUserUpdate;
@@ -96,11 +107,13 @@ export class UserComponent implements OnInit {
       .select(selectUserInfo)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((info) => {
+        this.storedEmail.set(info?.email ?? null);
         this.form.patchValue(info);
       });
     this.form.valueChanges
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(() => {
+        this.syncCurrentPassword();
         this.store.dispatch(UserActions.setForm({ form: this.value }));
       });
   }
@@ -119,6 +132,34 @@ export class UserComponent implements OnInit {
       password.disable();
       confirm_password.disable();
     }
+    this.syncCurrentPassword();
+  }
+
+  /**
+   * Enables the current password field only when the api will ask for it,
+   * so an unrelated edit such as the username stays a one field change.
+   */
+  private syncCurrentPassword(): void {
+    const control = this.form.controls.current_password;
+    const stored = this.storedEmail();
+    const needed =
+      this.form.controls.password.enabled ||
+      (!!stored && this.form.controls.email.value !== stored);
+
+    if (needed === this.needsCurrentPassword()) {
+      return;
+    }
+    this.needsCurrentPassword.set(needed);
+
+    if (needed) {
+      control.setValidators([Validators.required]);
+      control.enable({ emitEvent: false });
+    } else {
+      control.clearValidators();
+      control.setValue(null, { emitEvent: false });
+      control.disable({ emitEvent: false });
+    }
+    control.updateValueAndValidity({ emitEvent: false });
   }
 
   protected onSubmit(): void {


### PR DESCRIPTION
`PUT /user` accepts a new password, or a new email, on the strength of a valid access token alone. It also leaves every refresh token untouched.

That is enough for a full account takeover from a session that was never meant to grant it - a phone left unlocked, a session forgotten on a shared machine. The holder sets a new password, the owner is locked out, and the attacker's refresh token keeps working indefinitely. The email is in the same position: it is what `/recovery/code` trusts, so changing it is another route to the same place.

The recovery flow already gets this right - it revokes every refresh token after a reset. This brings `PUT /user` in line:

- the current password is required when the password or the email changes, and verified with `verify_password`
- refresh tokens are revoked after a password change
- changing only the username is untouched, no password needed

Frontend side, the current password field appears only when the api will ask for it, so editing a username stays a single-field change.

The access token is short lived and still valid until it expires, so the user is not thrown out mid-edit; the session simply cannot be renewed afterwards. Same behaviour as after a recovery.

Existing tests in `test_user.py` and `user.component.spec.ts` were updated for the new contract, and cases were added for a missing current password, a wrong one, session revocation, and the unrelated-edit path.

Happy to split the email half into its own PR if you would rather take the password part first.