### PR TITLE
fix: explicitly send a filename so iOS PWA logo uploads are not rejected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 **/cardholder_pwa.db
+.logos
 
 # Logs
 logs

--- a/backend/api/card_api.py
+++ b/backend/api/card_api.py
@@ -1,3 +1,5 @@
+import logging
+
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 from fastapi.responses import FileResponse
 from sqlalchemy import select
@@ -23,6 +25,7 @@ from backend.schemas.card_schema import (
 )
 
 router = APIRouter(tags=["card"])
+logger = logging.getLogger(__name__)
 
 
 @router.get("/cards", response_model=list[CardSchema])
@@ -198,6 +201,10 @@ async def upload_card_logo(
         # slow image cannot stall every other request being served.
         file_name = await run_in_threadpool(save_logo, raw)
     except LogoError as exc:
+        # Without this, a rejected upload is only the access-log 422 line,
+        # which is indistinguishable from FastAPI refusing the multipart
+        # before the handler (the iOS-PWA empty-filename case).
+        logger.warning("Rejected logo for card %s: %s", card_id, exc)
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 
     previous = card.logo_file

--- a/backend/app.py
+++ b/backend/app.py
@@ -2,7 +2,9 @@ import asyncio
 import logging
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.exception_handlers import request_validation_exception_handler
+from fastapi.exceptions import RequestValidationError
 
 from backend.api import (
     admin_router,
@@ -39,6 +41,25 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(root_path=Config.API_PATH, lifespan=lifespan)
+
+
+@app.exception_handler(RequestValidationError)
+async def log_request_validation_error(request: Request, exc: RequestValidationError):
+    # FastAPI 422s never reach the route, so they used to show up as a bare
+    # access-log line. Log loc/type/msg only: `input` can be the whole body.
+    logger = logging.getLogger("backend.validation")
+    logger.info(
+        "422 %s %s: %s",
+        request.method,
+        request.url.path,
+        [
+            {k: err[k] for k in ("type", "loc", "msg") if k in err}
+            for err in exc.errors()
+        ],
+    )
+    return await request_validation_exception_handler(request, exc)
+
+
 app.include_router(auth_router)
 app.include_router(user_router)
 app.include_router(card_router)

--- a/frontend/src/app/entities/cards/cards-api.service.spec.ts
+++ b/frontend/src/app/entities/cards/cards-api.service.spec.ts
@@ -1,0 +1,40 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { firstValueFrom } from 'rxjs';
+import { CardApiService } from './cards-api.service';
+
+describe('CardApiService', () => {
+  let service: CardApiService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(CardApiService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('should send a filename even when the File has none', async () => {
+    // Installed iOS PWAs often produce File objects with an empty name.
+    // FastAPI then 422s the multipart part unless filename= is present.
+    const file = new File([new Uint8Array([1, 2, 3])], '', {
+      type: 'image/jpeg',
+    });
+    const pending = firstValueFrom(service.uploadLogo(1, file));
+    const req = httpMock.expectOne('/api/cards/1/logo');
+    const body = req.request.body as FormData;
+    const uploaded = body.get('file') as File;
+
+    expect(uploaded).toBeInstanceOf(File);
+    expect(uploaded.name).toMatch(/^\d+\.jpg$/);
+    req.flush({ id: 1 });
+    await pending;
+  });
+});

--- a/frontend/src/app/entities/cards/cards-api.service.ts
+++ b/frontend/src/app/entities/cards/cards-api.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { ICard, ICardBase } from './cards-interface';
 import { Observable } from 'rxjs';
 import { BaseApiService } from '../base/base-api.service';
+import { filenameFor } from 'src/app/shared/functions/filename-for.function';
 
 @Injectable({
   providedIn: 'root',
@@ -53,7 +54,12 @@ export class CardApiService extends BaseApiService<'cards'> {
 
   uploadLogo(cardId: number, file: File): Observable<ICard> {
     const form = new FormData();
-    form.append('file', file);
+    // iOS WKWebView (installed PWA) often hands us a File with an empty name.
+    // FormData then omits `filename=` from Content-Disposition, Starlette
+    // treats the part as a regular form field, and FastAPI's
+    // `UploadFile = File(...)` rejects the request with 422 before the
+    // handler runs — which is why the server log is only the access line.
+    form.append('file', file, filenameFor(file));
     return this.httpClient.post<ICard>(`${this.basePath}/${cardId}/logo`, form);
   }
 

--- a/frontend/src/app/shared/functions/filename-for.function.spec.ts
+++ b/frontend/src/app/shared/functions/filename-for.function.spec.ts
@@ -1,0 +1,23 @@
+import { filenameFor } from './filename-for.function';
+
+describe('filenameFor', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should keep a real name', () => {
+    expect(filenameFor(new File([], 'shop.png', { type: 'image/png' }))).toBe(
+      'shop.png',
+    );
+  });
+
+  it('should invent a millisecond name when the file has none', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_735_372_145_123);
+    expect(filenameFor(new File([], '', { type: 'image/jpeg' }))).toBe(
+      '1735372145123.jpg',
+    );
+    expect(filenameFor(new File([], '  ', { type: 'image/png' }))).toBe(
+      '1735372145123.png',
+    );
+  });
+});

--- a/frontend/src/app/shared/functions/filename-for.function.ts
+++ b/frontend/src/app/shared/functions/filename-for.function.ts
@@ -1,0 +1,22 @@
+const FALLBACK_EXTENSIONS: Record<string, string> = {
+  'image/jpeg': '.jpg',
+  'image/jpg': '.jpg',
+  'image/png': '.png',
+  'image/webp': '.webp',
+  'image/gif': '.gif',
+  'image/bmp': '.bmp',
+  'image/svg+xml': '.svg',
+};
+
+/**
+ * Filename for a multipart upload. Never empty: iOS WKWebView often hands
+ * over a File with no name, and FastAPI then 422s the part.
+ * @param file file
+ */
+export const filenameFor = (file: File): string => {
+  const name = file.name?.trim();
+  if (name) {
+    return name;
+  }
+  return `${Date.now()}${FALLBACK_EXTENSIONS[file.type] ?? ''}`;
+};


### PR DESCRIPTION
- Implemented a custom exception handler for RequestValidationError to log validation errors in a structured format.
- Enhanced the card logo upload functionality to handle cases where the uploaded file may have an empty name, ensuring a valid filename is always sent to the server.
- Introduced a utility function to generate fallback filenames for files without a name.
- Added unit tests for the new filename generation logic and the CardApiService to ensure proper functionality.